### PR TITLE
Feat/show modal when data only

### DIFF
--- a/.changeset/fuzzy-nights-play.md
+++ b/.changeset/fuzzy-nights-play.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Removed alert dialog if there are no search results

--- a/apps/web/src/components/TermSelector/TermSelector.tsx
+++ b/apps/web/src/components/TermSelector/TermSelector.tsx
@@ -30,6 +30,21 @@ export default function TermSelector() {
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [pendingTerm, setPendingTerm] = useState<string | null>(null);
 
+  const handleChangeTerm = useCallback(
+    (term: string) => {
+      if (data === null) {
+        setSelectedTerm(term);
+        setData(null);
+        resetColours();
+        return;
+      }
+
+      setPendingTerm(term);
+      setIsAlertOpen(true);
+    },
+    [data, resetColours, setData, setSelectedTerm],
+  );
+
   const handleConfirmChangeTerm = useCallback(() => {
     if (pendingTerm) {
       setSelectedTerm(pendingTerm);
@@ -44,19 +59,6 @@ export default function TermSelector() {
     setIsAlertOpen(false);
     setPendingTerm(null);
   }, []);
-
-  const handleChangeTerm = useCallback(
-    (term: string) => {
-      setPendingTerm(term);
-
-      if (data === null) {
-        handleConfirmChangeTerm();
-        return;
-      }
-      setIsAlertOpen(true);
-    },
-    [data, handleConfirmChangeTerm],
-  );
 
   const hasInitialized = useRef(false);
   useEffect(() => {

--- a/apps/web/src/components/TermSelector/TermSelector.tsx
+++ b/apps/web/src/components/TermSelector/TermSelector.tsx
@@ -25,15 +25,10 @@ import {
 export default function TermSelector() {
   const { resetColours } = useColoursActions();
   const [selectedTerm, setSelectedTerm] = useTermParam();
-  const [, setData] = useDataParam();
+  const [data, setData] = useDataParam();
   const { data: availableTerms } = useAvailableTermsQuery();
   const [isAlertOpen, setIsAlertOpen] = useState(false);
   const [pendingTerm, setPendingTerm] = useState<string | null>(null);
-
-  const handleChangeTerm = useCallback((term: string) => {
-    setPendingTerm(term);
-    setIsAlertOpen(true);
-  }, []);
 
   const handleConfirmChangeTerm = useCallback(() => {
     if (pendingTerm) {
@@ -49,6 +44,19 @@ export default function TermSelector() {
     setIsAlertOpen(false);
     setPendingTerm(null);
   }, []);
+
+  const handleChangeTerm = useCallback(
+    (term: string) => {
+      setPendingTerm(term);
+
+      if (data === null) {
+        handleConfirmChangeTerm();
+        return;
+      }
+      setIsAlertOpen(true);
+    },
+    [data, handleConfirmChangeTerm],
+  );
 
   const hasInitialized = useRef(false);
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the user experience by removing the alert dialog when no search results are found, allowing for a smoother and less interruptive interface when searches return no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->