### PR TITLE
Add internationalization (i18n) support

### DIFF
--- a/.changeset/full-bees-win.md
+++ b/.changeset/full-bees-win.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Add initial i18n support with English and French translations.

--- a/apps/web/src/app/__root.tsx
+++ b/apps/web/src/app/__root.tsx
@@ -117,7 +117,7 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
 });
 
 function RootLayout() {
-  const { t } = useTranslation(); 
+  const { t } = useTranslation();
   return (
     <html lang="en" suppressHydrationWarning>
       <head>

--- a/apps/web/src/app/__root.tsx
+++ b/apps/web/src/app/__root.tsx
@@ -14,6 +14,8 @@ import { NuqsAdapter } from "nuqs/adapters/tanstack-router";
 import { Suspense } from "react";
 import { PostHogInit } from "@/components/PostHogInit";
 import appCss from "./app.css?url";
+import "@/i18n";
+import { useTranslation } from "react-i18next";
 
 const siteUrl = envClient.VITE_BASE_URL;
 const siteName = "uEnroll";
@@ -115,6 +117,7 @@ export const Route = createRootRouteWithContext<RouterAppContext>()({
 });
 
 function RootLayout() {
+  const { t } = useTranslation(); 
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
@@ -129,7 +132,7 @@ function RootLayout() {
         >
           <NuqsAdapter>
             <PostHogInit />
-            <Suspense fallback={<div>Loading...</div>}>
+            <Suspense fallback={<div>{t("common.loading")}</div>}>
               <Outlet />
             </Suspense>
             <Toaster richColors position="top-right" />

--- a/apps/web/src/components/Buttons/DeleteSearchResultsButton.tsx
+++ b/apps/web/src/components/Buttons/DeleteSearchResultsButton.tsx
@@ -18,7 +18,6 @@ export const DeleteSearchResultsButton = () => {
   const { resetSchedules } = useGeneratorActions();
   const { t } = useTranslation();
 
-
   const handleClick = useCallback(() => {
     resetColours();
     setData(null);

--- a/apps/web/src/components/Buttons/DeleteSearchResultsButton.tsx
+++ b/apps/web/src/components/Buttons/DeleteSearchResultsButton.tsx
@@ -9,12 +9,15 @@ import {
   TooltipTrigger,
 } from "@repo/ui/components/tooltip";
 import React, { useCallback } from "react";
+import { useTranslation } from "react-i18next";
 
 export const DeleteSearchResultsButton = () => {
   const { resetColours } = useColoursActions();
   const [data, setData] = useDataParam();
   const courseCodes = Object.keys(data ? data : {});
   const { resetSchedules } = useGeneratorActions();
+  const { t } = useTranslation();
+
 
   const handleClick = useCallback(() => {
     resetColours();
@@ -34,13 +37,13 @@ export const DeleteSearchResultsButton = () => {
             disabled={courseCodes.length === 0}
           >
             <Trash2 className="size-4" />
-            <p className="text-xs">Clear Results</p>
+            <p className="text-xs">{t("clearResults.button")}</p>
           </Button>
         }
       />
 
       <TooltipContent>
-        <p>Clear all search results</p>
+        <p>{t("clearResults.tooltip")}</p>
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/components/Buttons/ModeSwitcherButton.tsx
+++ b/apps/web/src/components/Buttons/ModeSwitcherButton.tsx
@@ -9,12 +9,14 @@ import { useMode, useUserSettingsActions } from "@/stores/modeStore";
 import { Selected } from "@/types/Types";
 import { useGeneratorActions } from "@/stores/generatorStore";
 import { useDataParam } from "@/hooks/useDataParam";
+import { useTranslation } from "react-i18next";
 
 export const ModeSwitcherButton = () => {
   const isGenerationMode = useMode();
   const [data, setData] = useDataParam();
   const { resetSchedules } = useGeneratorActions();
   const { toggleMode } = useUserSettingsActions();
+  const { t } = useTranslation();
 
   const handleToggle = () => {
     const courseCodes = Object.keys(data ? data : {});
@@ -24,6 +26,7 @@ export const ModeSwitcherButton = () => {
     resetSchedules();
     toggleMode();
   };
+  
 
   return (
     <Tooltip>
@@ -41,16 +44,16 @@ export const ModeSwitcherButton = () => {
               aria-hidden="true"
             />
             {isGenerationMode
-              ? "Schedule Generation on"
-              : "Schedule Generation off"}
+              ? t("scheduleGeneration.on")
+              : t("scheduleGeneration.off")}
           </Button>
         }
       />
 
       <TooltipContent>
         {isGenerationMode
-          ? "Switch back to manual section selection"
-          : "Automatically generate all possible schedules"}
+          ? t("scheduleGeneration.tooltip.on")
+          : t("scheduleGeneration.tooltip.off")}
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/components/Buttons/ModeSwitcherButton.tsx
+++ b/apps/web/src/components/Buttons/ModeSwitcherButton.tsx
@@ -26,7 +26,6 @@ export const ModeSwitcherButton = () => {
     resetSchedules();
     toggleMode();
   };
-  
 
   return (
     <Tooltip>

--- a/apps/web/src/components/Buttons/ThemeSwitchingButton.tsx
+++ b/apps/web/src/components/Buttons/ThemeSwitchingButton.tsx
@@ -8,6 +8,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@repo/ui/components/tooltip";
+import { useTranslation } from "react-i18next";
 
 export function ThemeSwitchingButton() {
   const { resolvedTheme, setTheme } = useTheme();
@@ -24,6 +25,7 @@ export function ThemeSwitchingButton() {
   };
 
   const Icon = mounted && resolvedTheme === "dark" ? Sun : Moon;
+  const { t } = useTranslation();
 
   return (
     <Tooltip>
@@ -42,7 +44,9 @@ export function ThemeSwitchingButton() {
       />
 
       <TooltipContent>
-        Change to {resolvedTheme === "dark" ? "Light mode" : "Dark mode"}
+        {resolvedTheme === "dark"
+          ? t("theme.switchToLight")
+          : t("theme.switchToDark")}
       </TooltipContent>
     </Tooltip>
   );

--- a/apps/web/src/components/EventCalendar/CalendarHeader.tsx
+++ b/apps/web/src/components/EventCalendar/CalendarHeader.tsx
@@ -10,6 +10,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@repo/ui/components/tooltip";
+import { useTranslation } from "react-i18next";
 
 interface CalendarHeaderProps {
   weekStart: Temporal.PlainDate;
@@ -26,14 +27,19 @@ export function CalendarHeader({
   onNavigate,
   onGoToTermStart,
 }: CalendarHeaderProps) {
+  const { t } = useTranslation();
+
+  const monthNamesShort = t("calendar.monthsShort", {
+    returnObjects: true,
+  }) as string[];
   return (
     <div className="flex items-center justify-between gap-4 border-b px-4 py-3">
       <div className="flex items-center gap-4">
         <Button variant="outline" size="sm" onClick={onGoToTermStart}>
-          Term Start
+          {t("calendar.termStart")}
         </Button>
         <h2 className="truncate text-base font-semibold text-nowrap">
-          {formatWeekRange(weekStart)}
+          {formatWeekRange(weekStart, monthNamesShort)}
         </h2>
       </div>
 
@@ -44,7 +50,10 @@ export function CalendarHeader({
             checked={weekendsHidden}
             onCheckedChange={onWeekendsHiddenChange}
           />
-          <span className="text-muted-foreground">Hide weekends</span>
+          <span className="text-muted-foreground">
+            {" "}
+            {t("calendar.hideWeekends")}
+          </span>
         </label>
 
         <div className="flex gap-2">
@@ -66,7 +75,7 @@ export function CalendarHeader({
               }
             />
 
-            <TooltipContent>Previous week</TooltipContent>
+            <TooltipContent>{t("calendar.previousWeek")}</TooltipContent>
           </Tooltip>
 
           <Tooltip>
@@ -82,7 +91,7 @@ export function CalendarHeader({
               }
             />
 
-            <TooltipContent>Next week</TooltipContent>
+            <TooltipContent>{t("calendar.nextWeek")}</TooltipContent>
           </Tooltip>
         </div>
       </div>

--- a/apps/web/src/components/EventCalendar/CalendarWrapper.tsx
+++ b/apps/web/src/components/EventCalendar/CalendarWrapper.tsx
@@ -15,8 +15,9 @@ import { GenerationHeader } from "./GenerationHeader";
 import { EventCalendar } from "@/components/EventCalendar/EventCalendar";
 
 const TERM_START_DATES = {
+  "2261": "2026-01-01", // Winter 2026
   "2265": "2026-05-04", // 2026 Spring/Summer Term
-  "2269": "2026-09-01", // Fall 2025
+  "2269": "2026-09-01", // Fall 2026
   "2271": "2027-01-01", // Winter 2027
 } as const;
 

--- a/apps/web/src/components/EventCalendar/GenerationHeader.tsx
+++ b/apps/web/src/components/EventCalendar/GenerationHeader.tsx
@@ -23,6 +23,8 @@ import {
 import { toast } from "sonner";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { ThemeSwitchingButton } from "@/components/Buttons/ThemeSwitchingButton";
+import { LanguageSwitcherButton } from "../Buttons/LanguageSwitcherButton";
+import { useTranslation } from "react-i18next";
 
 export function GenerationHeader() {
   const [loading, setLoading] = useState(false);
@@ -74,7 +76,7 @@ export function GenerationHeader() {
 
       // result[0] will be empty if there are search results but all components are unchecked
       if (result.length === 0 || result[0].length === 0) {
-        toast.error("No Possible Schedules. Adjust filters or remove courses.");
+        toast.error(t("scheduleGeneration.noSchedules"));
         return;
       }
       setSchedules(result);
@@ -125,6 +127,7 @@ export function GenerationHeader() {
 
     nextSchedule();
   };
+  const { t } = useTranslation();
 
   return (
     <div className="sticky top-0 z-10 flex items-center justify-between gap-2 rounded-b-lg border-b bg-background px-4 py-2 lg:rounded-lg lg:border">
@@ -162,7 +165,7 @@ export function GenerationHeader() {
               disabled={!isGenerationMode || noSchedules}
               value={
                 noSchedules
-                  ? `No results`
+                  ? t("scheduleGeneration.noResults")
                   : selectedSchedule !== null
                     ? selectedSchedule + 1
                     : ""
@@ -170,7 +173,7 @@ export function GenerationHeader() {
             />
             {!noSchedules && (
               <span className="flex h-full items-center border-y border-input bg-muted px-2 text-sm text-gray-500">
-                of {schedules.length}
+                {t("scheduleGeneration.of")} {schedules.length}
               </span>
             )}
           </div>
@@ -193,10 +196,10 @@ export function GenerationHeader() {
           className="px-2 text-xs lg:text-sm"
           onClick={handleGeneration}
         >
-          {loading ? "Loading..." : "Generate"}
+          {loading ? t("common.loading") : t("calendar.generate")}
         </Button>
       </div>
-
+      <LanguageSwitcherButton />
       <ThemeSwitchingButton />
     </div>
   );

--- a/apps/web/src/components/EventCalendar/GenerationHeader.tsx
+++ b/apps/web/src/components/EventCalendar/GenerationHeader.tsx
@@ -23,7 +23,6 @@ import {
 import { toast } from "sonner";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { ThemeSwitchingButton } from "@/components/Buttons/ThemeSwitchingButton";
-import { LanguageSwitcherButton } from "@/components/Buttons/LanguageSwitcherButton";
 import { useTranslation } from "react-i18next";
 
 export function GenerationHeader() {
@@ -199,7 +198,6 @@ export function GenerationHeader() {
           {loading ? t("common.loading") : t("calendar.generate")}
         </Button>
       </div>
-      <LanguageSwitcherButton />
       <ThemeSwitchingButton />
     </div>
   );

--- a/apps/web/src/components/EventCalendar/GenerationHeader.tsx
+++ b/apps/web/src/components/EventCalendar/GenerationHeader.tsx
@@ -23,7 +23,7 @@ import {
 import { toast } from "sonner";
 import { useScreenSize } from "@/hooks/useScreenSize";
 import { ThemeSwitchingButton } from "@/components/Buttons/ThemeSwitchingButton";
-import { LanguageSwitcherButton } from "../Buttons/LanguageSwitcherButton";
+import { LanguageSwitcherButton } from "@/components/Buttons/LanguageSwitcherButton";
 import { useTranslation } from "react-i18next";
 
 export function GenerationHeader() {

--- a/apps/web/src/components/EventCalendar/buildDayColumns.ts
+++ b/apps/web/src/components/EventCalendar/buildDayColumns.ts
@@ -50,7 +50,7 @@ export function buildDayColumns(
 
     return {
       date,
-      dayOfWeek: DAYS_OF_WEEK[date.dayOfWeek]!,
+      dayOfWeekKey: DAYS_OF_WEEK[date.dayOfWeek]!,
       dayNumber: date.day,
       isToday: isSameDay(date, today),
       events: positionedEvents,

--- a/apps/web/src/components/EventCalendar/constants.ts
+++ b/apps/web/src/components/EventCalendar/constants.ts
@@ -11,41 +11,11 @@ export const ANIMATION_DURATION = 200;
 export const TIME_COLUMN_WIDTH = 64;
 
 export const DAYS_OF_WEEK: Record<number, string> = {
-  1: "Mon",
-  2: "Tue",
-  3: "Wed",
-  4: "Thu",
-  5: "Fri",
-  6: "Sat",
-  7: "Sun",
+  1: "calendar.days.mon",
+  2: "calendar.days.tue",
+  3: "calendar.days.wed",
+  4: "calendar.days.thu",
+  5: "calendar.days.fri",
+  6: "calendar.days.sat",
+  7: "calendar.days.sun",
 };
-
-export const MONTH_NAMES_SHORT = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
-
-export const MONTH_NAMES_FULL = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];

--- a/apps/web/src/components/EventCalendar/dateUtils.ts
+++ b/apps/web/src/components/EventCalendar/dateUtils.ts
@@ -1,5 +1,4 @@
 import { Temporal } from "temporal-polyfill";
-import { MONTH_NAMES_SHORT, MONTH_NAMES_FULL } from "./constants";
 
 export function getWeekStart(date: Temporal.PlainDate): Temporal.PlainDate {
   // Temporal uses ISO weekday: 1 = Monday, 7 = Sunday
@@ -34,15 +33,21 @@ export function formatTime(zonedDateTime: Temporal.ZonedDateTime): string {
   return `${displayHour}:${displayMinute} ${period}`;
 }
 
-export function formatMonthYear(date: Temporal.PlainDate): string {
-  return `${MONTH_NAMES_FULL[date.month - 1]} ${date.year}`;
+export function formatMonthYear(
+  date: Temporal.PlainDate,
+  monthNamesFull: string[],
+): string {
+  return `${monthNamesFull[date.month - 1]} ${date.year}`;
 }
 
-export function formatWeekRange(weekStart: Temporal.PlainDate): string {
+export function formatWeekRange(
+  weekStart: Temporal.PlainDate,
+  monthNamesShort: string[],
+): string {
   const weekEnd = weekStart.add({ days: 6 });
 
-  const startMonth = MONTH_NAMES_SHORT[weekStart.month - 1];
-  const endMonth = MONTH_NAMES_SHORT[weekEnd.month - 1];
+  const startMonth = monthNamesShort[weekStart.month - 1];
+  const endMonth = monthNamesShort[weekEnd.month - 1];
 
   if (weekStart.month === weekEnd.month) {
     return `${startMonth} ${weekStart.day} - ${weekEnd.day}, ${weekStart.year}`;

--- a/apps/web/src/components/EventCalendar/internals/DayHeader.tsx
+++ b/apps/web/src/components/EventCalendar/internals/DayHeader.tsx
@@ -1,18 +1,27 @@
 import { DayColumn } from "@/components/EventCalendar/types";
+import { useTranslation } from "react-i18next";
 
-export const DayHeader = ({ column }: { column: DayColumn }) => (
-  <div
-    className={`flex flex-1 flex-col items-center justify-center border-r py-2 last:border-r-0 ${
-      column.isToday ? "bg-primary/10" : ""
-    }`}
-  >
-    <span className="text-xs text-muted-foreground">{column.dayOfWeek}</span>
-    <span
-      className={`flex h-6 w-6 items-center justify-center text-sm font-medium ${
-        column.isToday ? "rounded-full bg-primary text-primary-foreground" : ""
+export const DayHeader = ({ column }: { column: DayColumn }) => {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className={`flex flex-1 flex-col items-center justify-center border-r py-2 last:border-r-0 ${
+        column.isToday ? "bg-primary/10" : ""
       }`}
     >
-      {column.dayNumber}
-    </span>
-  </div>
-);
+      <span className="text-xs text-muted-foreground">
+        {t(column.dayOfWeekKey)}
+      </span>
+      <span
+        className={`flex h-6 w-6 items-center justify-center text-sm font-medium ${
+          column.isToday
+            ? "rounded-full bg-primary text-primary-foreground"
+            : ""
+        }`}
+      >
+        {column.dayNumber}
+      </span>
+    </div>
+  );
+};

--- a/apps/web/src/components/EventCalendar/types.ts
+++ b/apps/web/src/components/EventCalendar/types.ts
@@ -30,7 +30,7 @@ export interface PositionedEvent extends CalendarEvent {
 
 export interface DayColumn {
   date: Temporal.PlainDate;
-  dayOfWeek: string;
+  dayOfWeekKey: string;
   dayNumber: number;
   isToday: boolean;
   events: PositionedEvent[];

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearch.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearch.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import { AdvancedSearchDialog } from "./AdvancedSearchDialog";
 import { useTranslation } from "react-i18next";
 
-
 type AdvancedSearchProps = {
   term: string;
   selectedCodes: Set<string>;

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearch.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearch.tsx
@@ -2,6 +2,8 @@ import { Button } from "@repo/ui/components/button";
 import { SlidersHorizontalIcon } from "lucide-react";
 import { useState } from "react";
 import { AdvancedSearchDialog } from "./AdvancedSearchDialog";
+import { useTranslation } from "react-i18next";
+
 
 type AdvancedSearchProps = {
   term: string;
@@ -21,7 +23,7 @@ export function AdvancedSearch({
   onOpen,
 }: AdvancedSearchProps) {
   const [open, setOpen] = useState(false);
-
+  const { t } = useTranslation();
   return (
     <>
       <AdvancedSearchDialog
@@ -46,7 +48,7 @@ export function AdvancedSearch({
         }}
       >
         <SlidersHorizontalIcon className="size-4" />
-        <p className="text-xs">Advanced search</p>
+        <p className="text-xs">{t("advancedSearch.title")}</p>
       </Button>
     </>
   );

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchDialog.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchDialog.tsx
@@ -16,6 +16,7 @@ import {
 } from "./advanced-search-constants";
 import { AdvancedSearchFilters } from "./AdvancedSearchFilters";
 import { AdvancedSearchResults } from "./AdvancedSearchResults";
+import { useTranslation } from "react-i18next";
 
 type AdvancedSearchDialogProps = {
   open: boolean;
@@ -108,15 +109,15 @@ export function AdvancedSearchDialog({
     setLanguage(["any"]);
     setSubmittedFilters(null);
   };
+  const { t } = useTranslation();
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Advanced search</DialogTitle>
+          <DialogTitle>{t("advancedSearch.title")}</DialogTitle>
           <DialogDescription>
-            Filter by subject, year, or language, then add courses to your
-            playground.
+            {t("advancedSearch.description")}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchFilters.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchFilters.tsx
@@ -15,6 +15,7 @@ import {
   type YearValue,
   type LanguageValue,
 } from "./advanced-search-constants";
+import { useTranslation } from "react-i18next";
 
 type AdvancedSearchFiltersProps = {
   subject: string;
@@ -62,6 +63,7 @@ export function AdvancedSearchFilters({
       onSearch();
     }
   };
+  const { t } = useTranslation();
 
   return (
     <div className="flex flex-col gap-4">
@@ -69,7 +71,7 @@ export function AdvancedSearchFilters({
       <div>
         <div className="flex items-center justify-between">
           <Label className="mb-1.5" htmlFor="subject-filter">
-            Subject code
+            {t("advancedSearch.subjectCode")}
           </Label>
 
           <Button
@@ -82,7 +84,7 @@ export function AdvancedSearchFilters({
             className="invisible text-muted-foreground hover:text-primary disabled:opacity-0 data-[active=true]:visible"
           >
             <FilterXIcon className="size-3" />
-            Clear filters
+            {t("advancedSearch.clearFilters")}
           </Button>
         </div>
 
@@ -103,7 +105,7 @@ export function AdvancedSearchFilters({
 
           <Button size="default" disabled={!canSearch} onClick={onSearch}>
             <SearchIcon className="mr-1.5 size-3.5" />
-            Search
+            {t("advancedSearch.search")}
           </Button>
         </div>
       </div>
@@ -115,7 +117,7 @@ export function AdvancedSearchFilters({
             id="year-label"
             className="mb-1.5 text-xs tracking-wide text-muted-foreground uppercase"
           >
-            Year
+            {t("advancedSearch.year")}
           </Label>
 
           <ToggleGroup
@@ -136,7 +138,7 @@ export function AdvancedSearchFilters({
                 value={option.value}
                 className="aria-pressed:bg-primary/45 aria-pressed:text-primary-foreground"
               >
-                {option.label}
+                {t(option.labelKey)}
               </ToggleGroupItem>
             ))}
           </ToggleGroup>
@@ -147,7 +149,7 @@ export function AdvancedSearchFilters({
             id="language-label"
             className="mb-1.5 text-xs tracking-wide text-muted-foreground uppercase"
           >
-            Language
+            {t("advancedSearch.language")}
           </Label>
           <ToggleGroup
             aria-labelledby="language-label"
@@ -170,15 +172,15 @@ export function AdvancedSearchFilters({
                   value={option.value}
                   className="aria-pressed:bg-primary/45 aria-pressed:text-primary-foreground"
                 >
-                  {option.label}
+                  {t(option.labelKey)}
                 </ToggleGroupItem>
               );
 
-              if (option.description) {
+              if (option.descriptionKey ? t(option.descriptionKey) : null) {
                 return (
                   <Tooltip key={option.value}>
                     <TooltipTrigger render={toggle} />
-                    <TooltipContent>{option.description}</TooltipContent>
+                    <TooltipContent>{option.descriptionKey ? t(option.descriptionKey) : null}</TooltipContent>
                   </Tooltip>
                 );
               }

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchFilters.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchFilters.tsx
@@ -180,7 +180,9 @@ export function AdvancedSearchFilters({
                 return (
                   <Tooltip key={option.value}>
                     <TooltipTrigger render={toggle} />
-                    <TooltipContent>{option.descriptionKey ? t(option.descriptionKey) : null}</TooltipContent>
+                    <TooltipContent>
+                      {option.descriptionKey ? t(option.descriptionKey) : null}
+                    </TooltipContent>
                   </Tooltip>
                 );
               }

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchResults.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchResults.tsx
@@ -39,17 +39,20 @@ export function AdvancedSearchResults({
           {hasSubmitted
             ? isLoading
               ? t("advancedSearch.results.searching")
-              : `${t("advancedSearch.results.count", { count: courses.length })}${courses.length >= RESULTS_LIMIT
-                ? ` (${t("advancedSearch.results.limited", { limit: RESULTS_LIMIT })})`
-                : ""
-              }`
+              : `${t("advancedSearch.results.count", { count: courses.length })}${
+                  courses.length >= RESULTS_LIMIT
+                    ? ` (${t("advancedSearch.results.limited", { limit: RESULTS_LIMIT })})`
+                    : ""
+                }`
             : canSearch
               ? t("advancedSearch.results.pressSearch")
               : t("advancedSearch.results.setFilter")}
         </span>
         {isAtLimit && (
           <span className="font-medium text-destructive">
-            {t("advancedSearch.results.maxCourses", { count: MAX_RESULTS_ALLOWED })}
+            {t("advancedSearch.results.maxCourses", {
+              count: MAX_RESULTS_ALLOWED,
+            })}
           </span>
         )}
       </div>

--- a/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchResults.tsx
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/AdvancedSearchResults.tsx
@@ -8,6 +8,7 @@ import {
   BookOpenIcon,
 } from "lucide-react";
 import { RESULTS_LIMIT } from "./advanced-search-constants";
+import { useTranslation } from "react-i18next";
 
 type AdvancedSearchResultsProps = {
   hasSubmitted: boolean;
@@ -30,21 +31,25 @@ export function AdvancedSearchResults({
   isAtLimit,
   onAddCourse,
 }: AdvancedSearchResultsProps) {
+  const { t } = useTranslation();
   return (
     <div className="-mt-2 grid gap-2">
       <div className="flex items-center justify-between text-xs text-muted-foreground">
         <span>
           {hasSubmitted
             ? isLoading
-              ? "Searching..."
-              : `${courses.length} result${courses.length === 1 ? "" : "s"}${courses.length >= RESULTS_LIMIT ? ` (limited to ${RESULTS_LIMIT})` : ""}`
+              ? t("advancedSearch.results.searching")
+              : `${t("advancedSearch.results.count", { count: courses.length })}${courses.length >= RESULTS_LIMIT
+                ? ` (${t("advancedSearch.results.limited", { limit: RESULTS_LIMIT })})`
+                : ""
+              }`
             : canSearch
-              ? "Press Search to see results."
-              : "Set at least one filter to search."}
+              ? t("advancedSearch.results.pressSearch")
+              : t("advancedSearch.results.setFilter")}
         </span>
         {isAtLimit && (
           <span className="font-medium text-destructive">
-            Max {MAX_RESULTS_ALLOWED} courses
+            {t("advancedSearch.results.maxCourses", { count: MAX_RESULTS_ALLOWED })}
           </span>
         )}
       </div>
@@ -56,8 +61,8 @@ export function AdvancedSearchResults({
             <BookOpenIcon className="size-8 text-muted-foreground/50" />
             <p className="max-w-[18rem] text-center text-sm">
               {canSearch
-                ? "Ready to search. Press the Search button or hit Enter."
-                : "Enter a subject code, select a year, or choose a language to get started."}
+                ? t("advancedSearch.results.ready")
+                : t("advancedSearch.results.empty")}
             </p>
           </div>
         )}
@@ -66,7 +71,7 @@ export function AdvancedSearchResults({
         {hasSubmitted && isLoading && (
           <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-muted-foreground">
             <LoaderCircleIcon className="size-6 animate-spin text-primary/60" />
-            <p className="text-sm">Finding courses...</p>
+            <p className="text-sm">{t("advancedSearch.results.finding")}</p>
           </div>
         )}
 
@@ -74,7 +79,7 @@ export function AdvancedSearchResults({
         {hasSubmitted && !isLoading && courses.length === 0 && (
           <div className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-muted-foreground">
             <SearchIcon className="size-6 text-muted-foreground/50" />
-            <p className="text-sm">No courses match those filters.</p>
+            <p className="text-sm">{t("advancedSearch.results.noMatch")}</p>
           </div>
         )}
 
@@ -110,12 +115,12 @@ export function AdvancedSearchResults({
                           strokeWidth={3}
                           className="mr-1 size-4 text-emerald-500"
                         />
-                        Added
+                        {t("advancedSearch.results.added")}
                       </>
                     ) : (
                       <>
                         <PlusIcon className="mr-1 size-3" />
-                        Add
+                        {t("advancedSearch.results.add")}
                       </>
                     )}
                   </Button>

--- a/apps/web/src/components/SearchBar/AdvancedSearch/advanced-search-constants.ts
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/advanced-search-constants.ts
@@ -4,13 +4,21 @@ export const YEAR_OPTIONS = [
   { labelKey: "advancedSearch.years.second", value: "2" },
   { labelKey: "advancedSearch.years.third", value: "3" },
   { labelKey: "advancedSearch.years.fourth", value: "4" },
-  { labelKey: "advancedSearch.years.grad", value: "5" }
+  { labelKey: "advancedSearch.years.grad", value: "5" },
 ] as const;
 
 export const LANGUAGE_OPTIONS = [
   { labelKey: "advancedSearch.any", value: "any", descriptionKey: undefined },
-  { labelKey: "advancedSearch.languages.english", value: "english", descriptionKey: undefined },
-  { labelKey: "advancedSearch.languages.french", value: "french", descriptionKey: undefined },
+  {
+    labelKey: "advancedSearch.languages.english",
+    value: "english",
+    descriptionKey: undefined,
+  },
+  {
+    labelKey: "advancedSearch.languages.french",
+    value: "french",
+    descriptionKey: undefined,
+  },
   {
     labelKey: "advancedSearch.languages.other",
     value: "other",

--- a/apps/web/src/components/SearchBar/AdvancedSearch/advanced-search-constants.ts
+++ b/apps/web/src/components/SearchBar/AdvancedSearch/advanced-search-constants.ts
@@ -1,20 +1,20 @@
 export const YEAR_OPTIONS = [
-  { label: "Any", value: "any" },
-  { label: "1st", value: "1" },
-  { label: "2nd", value: "2" },
-  { label: "3rd", value: "3" },
-  { label: "4th", value: "4" },
-  { label: "Grad", value: "5" },
+  { labelKey: "advancedSearch.any", value: "any" },
+  { labelKey: "advancedSearch.years.first", value: "1" },
+  { labelKey: "advancedSearch.years.second", value: "2" },
+  { labelKey: "advancedSearch.years.third", value: "3" },
+  { labelKey: "advancedSearch.years.fourth", value: "4" },
+  { labelKey: "advancedSearch.years.grad", value: "5" }
 ] as const;
 
 export const LANGUAGE_OPTIONS = [
-  { label: "Any", value: "any", description: undefined },
-  { label: "English", value: "english", description: undefined },
-  { label: "French", value: "french", description: undefined },
+  { labelKey: "advancedSearch.any", value: "any", descriptionKey: undefined },
+  { labelKey: "advancedSearch.languages.english", value: "english", descriptionKey: undefined },
+  { labelKey: "advancedSearch.languages.french", value: "french", descriptionKey: undefined },
   {
-    label: "Other",
+    labelKey: "advancedSearch.languages.other",
     value: "other",
-    description: "Bilingual or other languages (e.g. Spanish)",
+    descriptionKey: "advancedSearch.languageDescriptions.other",
   },
 ] as const;
 

--- a/apps/web/src/components/SearchBar/Autocomplete.tsx
+++ b/apps/web/src/components/SearchBar/Autocomplete.tsx
@@ -28,6 +28,7 @@ import { SearchIcon, LoaderCircleIcon } from "lucide-react";
 import { AdvancedSearch } from "./AdvancedSearch/AdvancedSearch";
 import { DeleteSearchResultsButton } from "@/components/Buttons/DeleteSearchResultsButton";
 import { ModeSwitcherButton } from "@/components/Buttons/ModeSwitcherButton";
+import { useTranslation } from "react-i18next";
 
 interface CourseMatch {
   courseCode: string;
@@ -58,6 +59,7 @@ export default function Autocomplete() {
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
   const trpc = useTRPC();
+  const { t } = useTranslation();
 
   const deferredQuery = useDeferredValue(
     stripSpacesFromCourseCode(query.trim()),
@@ -93,12 +95,12 @@ export default function Autocomplete() {
   const addCourse = useCallback(
     async (courseCode: string) => {
       if (selectedCodes.has(courseCode)) {
-        toast.info(`${courseCode} is already selected`);
+        toast.info(t("errors.alreadySelected", { courseCode }));
         return;
       }
 
       if (isAtLimit) {
-        toast.error(`Maximum of ${MAX_RESULTS_ALLOWED} courses allowed`);
+        toast.error(t("errors.maxCoursesAllowed", { count: MAX_RESULTS_ALLOWED }));
         return;
       }
 
@@ -114,9 +116,7 @@ export default function Autocomplete() {
         const next = { ...(data ?? {}), [courseCode]: [] };
         setData(next);
       } catch (err) {
-        toast.error(
-          err instanceof Error ? err.message : "Failed to add course",
-        );
+        toast.error(t("errors.failedToAddCourse"));
       } finally {
         setIsAdding(false);
         setQuery("");
@@ -188,7 +188,7 @@ export default function Autocomplete() {
                   if (deferredQuery) setOpen(true);
                 }}
                 onKeyDown={handleKeyDown}
-                placeholder="Search for a course..."
+                placeholder={t("search.placeholder")}
                 disabled={isAdding}
               />
             </InputGroup>
@@ -202,7 +202,7 @@ export default function Autocomplete() {
         >
           {results.length === 0 && (
             <p className="px-3 py-4 text-center text-sm text-muted-foreground">
-              No courses found
+              {t("errors.noCourseFound")}
             </p>
           )}
 

--- a/apps/web/src/components/SearchBar/Autocomplete.tsx
+++ b/apps/web/src/components/SearchBar/Autocomplete.tsx
@@ -100,7 +100,9 @@ export default function Autocomplete() {
       }
 
       if (isAtLimit) {
-        toast.error(t("errors.maxCoursesAllowed", { count: MAX_RESULTS_ALLOWED }));
+        toast.error(
+          t("errors.maxCoursesAllowed", { count: MAX_RESULTS_ALLOWED }),
+        );
         return;
       }
 
@@ -125,7 +127,16 @@ export default function Autocomplete() {
         requestAnimationFrame(() => inputRef.current?.focus());
       }
     },
-    [selectedCodes, isAtLimit, queryClient, trpc, selectedTerm, data, setData, t],
+    [
+      selectedCodes,
+      isAtLimit,
+      queryClient,
+      trpc,
+      selectedTerm,
+      data,
+      setData,
+      t,
+    ],
   );
 
   const handleKeyDown = useCallback(

--- a/apps/web/src/components/SearchBar/Autocomplete.tsx
+++ b/apps/web/src/components/SearchBar/Autocomplete.tsx
@@ -115,7 +115,7 @@ export default function Autocomplete() {
 
         const next = { ...(data ?? {}), [courseCode]: [] };
         setData(next);
-      } catch (err) {
+      } catch {
         toast.error(t("errors.failedToAddCourse"));
       } finally {
         setIsAdding(false);
@@ -125,7 +125,7 @@ export default function Autocomplete() {
         requestAnimationFrame(() => inputRef.current?.focus());
       }
     },
-    [selectedCodes, isAtLimit, queryClient, trpc, selectedTerm, data, setData],
+    [selectedCodes, isAtLimit, queryClient, trpc, selectedTerm, data, setData, t],
   );
 
   const handleKeyDown = useCallback(

--- a/apps/web/src/components/SearchResults/SearchResults.tsx
+++ b/apps/web/src/components/SearchResults/SearchResults.tsx
@@ -8,11 +8,13 @@ import { useCourseQueries } from "@/hooks/useCourseQueries";
 import { useTermParam } from "@/hooks/useTermParam";
 import { useDataParam } from "@/hooks/useDataParam";
 import { useMode } from "@/stores/modeStore";
+import { useTranslation } from "react-i18next";
 
 export default function SearchResults() {
   const [data] = useDataParam();
   const [selectedTerm] = useTermParam();
   const isGenerationMode = useMode();
+  const { t } = useTranslation();
 
   const [openResults, setOpenResults] = useState<string[]>([]);
 
@@ -25,7 +27,7 @@ export default function SearchResults() {
   );
 
   if (courseQueries.some(query => query.isLoading)) {
-    return <div>Loading...</div>;
+    return <div>{t("common.loading")}</div>;
   }
 
   const courseSearchResults = courseQueries
@@ -47,7 +49,7 @@ export default function SearchResults() {
                   className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
                   aria-label={`Open ${course.courseCode} on uo.grades.zone`}
                 >
-                  <span>Grades on uo.grades.zone</span>
+                  <span>{t("grades.uoGradesZone")}</span>
                   <ExternalLink className="size-3" aria-hidden="true" />
                 </a>
               </div>

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -74,5 +74,53 @@
   },
   "grades": {
     "uoGradesZone": "Grades on uo.grades.zone"
+  },
+  "calendar": {
+    "termStart": "Term Start",
+    "hideWeekends": "Hide weekends",
+    "generate": "Generate",
+    "days": {
+      "mon": "Mon",
+      "tue": "Tue",
+      "wed": "Wed",
+      "thu": "Thu",
+      "fri": "Fri",
+      "sat": "Sat",
+      "sun": "Sun"
+    },
+    "monthsShort": [
+      "Jan",
+      "Feb",
+      "Mar",
+      "Apr",
+      "May",
+      "Jun",
+      "Jul",
+      "Aug",
+      "Sep",
+      "Oct",
+      "Nov",
+      "Dec"
+    ],
+    "monthsFull": [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December"
+    ],
+    "previousWeek": "Previous week",
+    "nextWeek": "Next week"
+  },
+  "theme": {
+    "switchToLight": "Switch to light mode",
+    "switchToDark": "Switch to dark mode"
   }
 }

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -1,0 +1,78 @@
+{
+    "term": {
+        "springSummer2025": "2025 Spring/Summer Term"
+    },
+    "search": {
+        "placeholder": "Search for a course..."
+    },
+    "scheduleGeneration": {
+        "off": "Schedule Generation off",
+        "on": "Schedule Generation on",
+        "tooltip": {
+            "on": "Switch back to manual section selection",
+            "off": "Automatically generate all possible schedules"
+        }
+    },
+    "clearResults": {
+        "button": "Clear Results",
+        "tooltip": "Clear all search results"
+    },
+    "footer": {
+        "maintainedBy": "Maintained by"
+    },
+    "errors": {
+        "failedToAddCourse": "Failed to add course",
+        "maxCoursesAllowed": "Maximum of {{count}} courses allowed",
+        "alreadySelected": "{{courseCode}} is already selected",
+        "missingEnvironmentVariables": "Missing environment variables",
+        "noCourseFound": "No courses found"
+    },
+    "advancedSearch": {
+        "title": "Advanced search",
+        "description": "Filter by subject, year, or language, then add courses to your playground.",
+        "subjectCode": "Subject code",
+        "search": "Search",
+        "year": "Year",
+        "years": {
+            "first": "1st",
+            "second": "2nd",
+            "third": "3rd",
+            "fourth": "4th",
+            "grad": "Grad"
+        },
+        "languages": {
+            "english": "English",
+            "french": "French",
+            "other": "Other"
+        },
+        "languageDescriptions": {
+            "other": "Bilingual or other languages (e.g. Spanish)"
+        },
+        "any": "Any",
+        "language": "Language",
+        "setFilter": "Set at least one filter to search.",
+        "emptyState": "Enter a subject code, select a year, or choose a language to get started.",
+        "clearFilters": "Clear filters",
+        "results": {
+            "searching": "Searching...",
+            "count_one": "{{count}} result",
+            "count_other": "{{count}} results",
+            "limited": "limited to {{limit}}",
+            "pressSearch": "Press Search to see results.",
+            "setFilter": "Set at least one filter to search.",
+            "maxCourses": "Max {{count}} courses",
+            "ready": "Ready to search. Press the Search button or hit Enter.",
+            "empty": "Enter a subject code, select a year, or choose a language to get started.",
+            "finding": "Finding courses...",
+            "noMatch": "No courses match those filters.",
+            "added": "Added",
+            "add": "Add"
+        }
+    },
+    "common": {
+        "loading": "Loading..."
+    },
+    "grades": {
+        "uoGradesZone": "Grades on uo.grades.zone"
+    }
+}

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -1,78 +1,78 @@
 {
-    "term": {
-        "springSummer2025": "2025 Spring/Summer Term"
-    },
-    "search": {
-        "placeholder": "Search for a course..."
-    },
-    "scheduleGeneration": {
-        "off": "Schedule Generation off",
-        "on": "Schedule Generation on",
-        "tooltip": {
-            "on": "Switch back to manual section selection",
-            "off": "Automatically generate all possible schedules"
-        }
-    },
-    "clearResults": {
-        "button": "Clear Results",
-        "tooltip": "Clear all search results"
-    },
-    "footer": {
-        "maintainedBy": "Maintained by"
-    },
-    "errors": {
-        "failedToAddCourse": "Failed to add course",
-        "maxCoursesAllowed": "Maximum of {{count}} courses allowed",
-        "alreadySelected": "{{courseCode}} is already selected",
-        "missingEnvironmentVariables": "Missing environment variables",
-        "noCourseFound": "No courses found"
-    },
-    "advancedSearch": {
-        "title": "Advanced search",
-        "description": "Filter by subject, year, or language, then add courses to your playground.",
-        "subjectCode": "Subject code",
-        "search": "Search",
-        "year": "Year",
-        "years": {
-            "first": "1st",
-            "second": "2nd",
-            "third": "3rd",
-            "fourth": "4th",
-            "grad": "Grad"
-        },
-        "languages": {
-            "english": "English",
-            "french": "French",
-            "other": "Other"
-        },
-        "languageDescriptions": {
-            "other": "Bilingual or other languages (e.g. Spanish)"
-        },
-        "any": "Any",
-        "language": "Language",
-        "setFilter": "Set at least one filter to search.",
-        "emptyState": "Enter a subject code, select a year, or choose a language to get started.",
-        "clearFilters": "Clear filters",
-        "results": {
-            "searching": "Searching...",
-            "count_one": "{{count}} result",
-            "count_other": "{{count}} results",
-            "limited": "limited to {{limit}}",
-            "pressSearch": "Press Search to see results.",
-            "setFilter": "Set at least one filter to search.",
-            "maxCourses": "Max {{count}} courses",
-            "ready": "Ready to search. Press the Search button or hit Enter.",
-            "empty": "Enter a subject code, select a year, or choose a language to get started.",
-            "finding": "Finding courses...",
-            "noMatch": "No courses match those filters.",
-            "added": "Added",
-            "add": "Add"
-        }
-    },
-    "common": {
-        "loading": "Loading..."
-    },
-    "grades": {
-        "uoGradesZone": "Grades on uo.grades.zone"
+  "term": {
+    "springSummer2025": "2025 Spring/Summer Term"
+  },
+  "search": {
+    "placeholder": "Search for a course..."
+  },
+  "scheduleGeneration": {
+    "off": "Schedule Generation off",
+    "on": "Schedule Generation on",
+    "tooltip": {
+      "on": "Switch back to manual section selection",
+      "off": "Automatically generate all possible schedules"
     }
+  },
+  "clearResults": {
+    "button": "Clear Results",
+    "tooltip": "Clear all search results"
+  },
+  "footer": {
+    "maintainedBy": "Maintained by"
+  },
+  "errors": {
+    "failedToAddCourse": "Failed to add course",
+    "maxCoursesAllowed": "Maximum of {{count}} courses allowed",
+    "alreadySelected": "{{courseCode}} is already selected",
+    "missingEnvironmentVariables": "Missing environment variables",
+    "noCourseFound": "No courses found"
+  },
+  "advancedSearch": {
+    "title": "Advanced search",
+    "description": "Filter by subject, year, or language, then add courses to your playground.",
+    "subjectCode": "Subject code",
+    "search": "Search",
+    "year": "Year",
+    "years": {
+      "first": "1st",
+      "second": "2nd",
+      "third": "3rd",
+      "fourth": "4th",
+      "grad": "Grad"
+    },
+    "languages": {
+      "english": "English",
+      "french": "French",
+      "other": "Other"
+    },
+    "languageDescriptions": {
+      "other": "Bilingual or other languages (e.g. Spanish)"
+    },
+    "any": "Any",
+    "language": "Language",
+    "setFilter": "Set at least one filter to search.",
+    "emptyState": "Enter a subject code, select a year, or choose a language to get started.",
+    "clearFilters": "Clear filters",
+    "results": {
+      "searching": "Searching...",
+      "count_one": "{{count}} result",
+      "count_other": "{{count}} results",
+      "limited": "limited to {{limit}}",
+      "pressSearch": "Press Search to see results.",
+      "setFilter": "Set at least one filter to search.",
+      "maxCourses": "Max {{count}} courses",
+      "ready": "Ready to search. Press the Search button or hit Enter.",
+      "empty": "Enter a subject code, select a year, or choose a language to get started.",
+      "finding": "Finding courses...",
+      "noMatch": "No courses match those filters.",
+      "added": "Added",
+      "add": "Add"
+    }
+  },
+  "common": {
+    "loading": "Loading..."
+  },
+  "grades": {
+    "uoGradesZone": "Grades on uo.grades.zone"
+  }
 }

--- a/apps/web/src/i18n/en.json
+++ b/apps/web/src/i18n/en.json
@@ -51,7 +51,6 @@
     "any": "Any",
     "language": "Language",
     "setFilter": "Set at least one filter to search.",
-    "emptyState": "Enter a subject code, select a year, or choose a language to get started.",
     "clearFilters": "Clear filters",
     "results": {
       "searching": "Searching...",

--- a/apps/web/src/i18n/fr.json
+++ b/apps/web/src/i18n/fr.json
@@ -74,5 +74,53 @@
   },
   "grades": {
     "uoGradesZone": "Notes sur uo.grades.zone"
+  },
+  "calendar": {
+    "termStart": "Début du trimestre",
+    "hideWeekends": "Masquer les fins de semaine",
+    "generate": "Générer",
+    "days": {
+      "mon": "Lun",
+      "tue": "Mar",
+      "wed": "Mer",
+      "thu": "Jeu",
+      "fri": "Ven",
+      "sat": "Sam",
+      "sun": "Dim"
+    },
+    "monthsShort": [
+      "janv.",
+      "févr.",
+      "mars",
+      "avr.",
+      "mai",
+      "juin",
+      "juill.",
+      "août",
+      "sept.",
+      "oct.",
+      "nov.",
+      "déc."
+    ],
+    "monthsFull": [
+      "janvier",
+      "février",
+      "mars",
+      "avril",
+      "mai",
+      "juin",
+      "juillet",
+      "août",
+      "septembre",
+      "octobre",
+      "novembre",
+      "décembre"
+    ],
+    "previousWeek": "Semaine précédente",
+    "nextWeek": "Semaine suivante"
+  },
+  "theme": {
+    "switchToLight": "Passer au mode clair",
+    "switchToDark": "Passer au mode sombre"
   }
 }

--- a/apps/web/src/i18n/fr.json
+++ b/apps/web/src/i18n/fr.json
@@ -51,7 +51,6 @@
     "any": "Tous",
     "language": "Langue",
     "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
-    "emptyState": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
     "clearFilters": "Effacer les filtres",
     "results": {
       "searching": "Recherche en cours...",

--- a/apps/web/src/i18n/fr.json
+++ b/apps/web/src/i18n/fr.json
@@ -1,0 +1,78 @@
+{
+    "term": {
+        "springSummer2025": "Trimestre printemps/été 2025"
+    },
+    "search": {
+        "placeholder": "Rechercher un cours..."
+    },
+    "scheduleGeneration": {
+        "off": "Génération d’horaire désactivée",
+        "on": "Génération d’horaire activée",
+        "tooltip": {
+            "on": "Revenir à la sélection manuelle des sections",
+            "off": "Générer automatiquement tous les horaires possibles"
+        }
+    },
+    "clearResults": {
+        "button": "Effacer les résultats",
+        "tooltip": "Effacer tous les résultats de recherche"
+    },
+    "footer": {
+        "maintainedBy": "Maintenu par"
+    },
+    "errors": {
+        "failedToAddCourse": "Impossible d’ajouter le cours",
+        "maxCoursesAllowed": "Un maximum de {{count}} cours est autorisé",
+        "alreadySelected": "{{courseCode}} est déjà sélectionné",
+        "missingEnvironmentVariables": "Variables d’environnement manquantes",
+        "noCourseFound": "Aucun cours trouvé"
+    },
+    "advancedSearch": {
+        "title": "Recherche avancée",
+        "description": "Filtrez par matière, année ou langue, puis ajoutez des cours à votre horaire.",
+        "subjectCode": "Code de matière",
+        "search": "Rechercher",
+        "year": "Année",
+        "years": {
+            "first": "1re",
+            "second": "2e",
+            "third": "3e",
+            "fourth": "4e",
+            "grad": "Cycles supérieurs"
+        },
+        "languages": {
+            "english": "Anglais",
+            "french": "Français",
+            "other": "Autre"
+        },
+        "languageDescriptions": {
+            "other": "Bilingue ou autres langues (ex. espagnol)"
+        },
+        "any": "Tous",
+        "language": "Langue",
+        "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
+        "emptyState": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
+        "clearFilters": "Effacer les filtres",
+        "results": {
+            "searching": "Recherche en cours...",
+            "count_one": "{{count}} résultat",
+            "count_other": "{{count}} résultats",
+            "limited": "limité à {{limit}}",
+            "pressSearch": "Appuyez sur Rechercher pour voir les résultats.",
+            "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
+            "maxCourses": "Max {{count}} cours",
+            "ready": "Prêt à rechercher. Appuyez sur Rechercher ou sur Entrée.",
+            "empty": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
+            "finding": "Recherche des cours...",
+            "noMatch": "Aucun cours ne correspond à ces filtres.",
+            "added": "Ajouté",
+            "add": "Ajouter"
+        }
+    },
+    "common": {
+        "loading": "Chargement..."
+    },
+    "grades": {
+        "uoGradesZone": "Notes sur uo.grades.zone"
+    }
+}

--- a/apps/web/src/i18n/fr.json
+++ b/apps/web/src/i18n/fr.json
@@ -1,78 +1,78 @@
 {
-    "term": {
-        "springSummer2025": "Trimestre printemps/été 2025"
-    },
-    "search": {
-        "placeholder": "Rechercher un cours..."
-    },
-    "scheduleGeneration": {
-        "off": "Génération d’horaire désactivée",
-        "on": "Génération d’horaire activée",
-        "tooltip": {
-            "on": "Revenir à la sélection manuelle des sections",
-            "off": "Générer automatiquement tous les horaires possibles"
-        }
-    },
-    "clearResults": {
-        "button": "Effacer les résultats",
-        "tooltip": "Effacer tous les résultats de recherche"
-    },
-    "footer": {
-        "maintainedBy": "Maintenu par"
-    },
-    "errors": {
-        "failedToAddCourse": "Impossible d’ajouter le cours",
-        "maxCoursesAllowed": "Un maximum de {{count}} cours est autorisé",
-        "alreadySelected": "{{courseCode}} est déjà sélectionné",
-        "missingEnvironmentVariables": "Variables d’environnement manquantes",
-        "noCourseFound": "Aucun cours trouvé"
-    },
-    "advancedSearch": {
-        "title": "Recherche avancée",
-        "description": "Filtrez par matière, année ou langue, puis ajoutez des cours à votre horaire.",
-        "subjectCode": "Code de matière",
-        "search": "Rechercher",
-        "year": "Année",
-        "years": {
-            "first": "1re",
-            "second": "2e",
-            "third": "3e",
-            "fourth": "4e",
-            "grad": "Cycles supérieurs"
-        },
-        "languages": {
-            "english": "Anglais",
-            "french": "Français",
-            "other": "Autre"
-        },
-        "languageDescriptions": {
-            "other": "Bilingue ou autres langues (ex. espagnol)"
-        },
-        "any": "Tous",
-        "language": "Langue",
-        "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
-        "emptyState": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
-        "clearFilters": "Effacer les filtres",
-        "results": {
-            "searching": "Recherche en cours...",
-            "count_one": "{{count}} résultat",
-            "count_other": "{{count}} résultats",
-            "limited": "limité à {{limit}}",
-            "pressSearch": "Appuyez sur Rechercher pour voir les résultats.",
-            "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
-            "maxCourses": "Max {{count}} cours",
-            "ready": "Prêt à rechercher. Appuyez sur Rechercher ou sur Entrée.",
-            "empty": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
-            "finding": "Recherche des cours...",
-            "noMatch": "Aucun cours ne correspond à ces filtres.",
-            "added": "Ajouté",
-            "add": "Ajouter"
-        }
-    },
-    "common": {
-        "loading": "Chargement..."
-    },
-    "grades": {
-        "uoGradesZone": "Notes sur uo.grades.zone"
+  "term": {
+    "springSummer2025": "Trimestre printemps/été 2025"
+  },
+  "search": {
+    "placeholder": "Rechercher un cours..."
+  },
+  "scheduleGeneration": {
+    "off": "Génération d’horaire désactivée",
+    "on": "Génération d’horaire activée",
+    "tooltip": {
+      "on": "Revenir à la sélection manuelle des sections",
+      "off": "Générer automatiquement tous les horaires possibles"
     }
+  },
+  "clearResults": {
+    "button": "Effacer les résultats",
+    "tooltip": "Effacer tous les résultats de recherche"
+  },
+  "footer": {
+    "maintainedBy": "Maintenu par"
+  },
+  "errors": {
+    "failedToAddCourse": "Impossible d’ajouter le cours",
+    "maxCoursesAllowed": "Un maximum de {{count}} cours est autorisé",
+    "alreadySelected": "{{courseCode}} est déjà sélectionné",
+    "missingEnvironmentVariables": "Variables d’environnement manquantes",
+    "noCourseFound": "Aucun cours trouvé"
+  },
+  "advancedSearch": {
+    "title": "Recherche avancée",
+    "description": "Filtrez par matière, année ou langue, puis ajoutez des cours à votre horaire.",
+    "subjectCode": "Code de matière",
+    "search": "Rechercher",
+    "year": "Année",
+    "years": {
+      "first": "1re",
+      "second": "2e",
+      "third": "3e",
+      "fourth": "4e",
+      "grad": "Cycles supérieurs"
+    },
+    "languages": {
+      "english": "Anglais",
+      "french": "Français",
+      "other": "Autre"
+    },
+    "languageDescriptions": {
+      "other": "Bilingue ou autres langues (ex. espagnol)"
+    },
+    "any": "Tous",
+    "language": "Langue",
+    "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
+    "emptyState": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
+    "clearFilters": "Effacer les filtres",
+    "results": {
+      "searching": "Recherche en cours...",
+      "count_one": "{{count}} résultat",
+      "count_other": "{{count}} résultats",
+      "limited": "limité à {{limit}}",
+      "pressSearch": "Appuyez sur Rechercher pour voir les résultats.",
+      "setFilter": "Sélectionnez au moins un filtre pour rechercher.",
+      "maxCourses": "Max {{count}} cours",
+      "ready": "Prêt à rechercher. Appuyez sur Rechercher ou sur Entrée.",
+      "empty": "Entrez un code de matière, sélectionnez une année ou choisissez une langue pour commencer.",
+      "finding": "Recherche des cours...",
+      "noMatch": "Aucun cours ne correspond à ces filtres.",
+      "added": "Ajouté",
+      "add": "Ajouter"
+    }
+  },
+  "common": {
+    "loading": "Chargement..."
+  },
+  "grades": {
+    "uoGradesZone": "Notes sur uo.grades.zone"
+  }
 }

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -8,13 +8,13 @@ import fr from "./fr.json";
 i18n.use(initReactI18next).init({
   resources: {
     en: { translation: en },
-    fr: { translation: fr }
+    fr: { translation: fr },
   },
   lng: "fr",
   fallbackLng: "en",
   interpolation: {
-    escapeValue: false
-  }
+    escapeValue: false,
+  },
 });
 
 export default i18n;

--- a/apps/web/src/i18n/index.ts
+++ b/apps/web/src/i18n/index.ts
@@ -1,0 +1,20 @@
+// apps/web/src/i18n/index.ts
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import en from "./en.json";
+import fr from "./fr.json";
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    fr: { translation: fr }
+  },
+  lng: "fr",
+  fallbackLng: "en",
+  interpolation: {
+    escapeValue: false
+  }
+});
+
+export default i18n;

--- a/apps/web/src/layouts/Footer/Footer.tsx
+++ b/apps/web/src/layouts/Footer/Footer.tsx
@@ -1,10 +1,12 @@
 import { Button } from "@repo/ui/components/button";
+import { useTranslation } from "react-i18next";
 
 export const Footer = () => {
   const year = new Date().getFullYear();
+  const { t } = useTranslation();
   return (
     <div className="mt-auto hidden text-center text-sm md:block">
-      <p className="inline-block">Mantained by</p>
+      <p className="inline-block">{t("footer.maintainedBy")}</p>
       &nbsp;
       <Button
         nativeButton={false}

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "uenroll",
       "dependencies": {
+        "i18next": "^26.2.0",
         "minimatch": "^10.2.5",
+        "react-i18next": "^17.0.8",
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.7.0",
@@ -1202,9 +1204,13 @@
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
+    "html-parse-stringify": ["html-parse-stringify@3.0.1", "", { "dependencies": { "void-elements": "3.1.0" } }, "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg=="],
+
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "human-id": ["human-id@4.1.3", "", { "bin": { "human-id": "dist/cli.js" } }, "sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q=="],
+
+    "i18next": ["i18next@26.2.0", "", { "peerDependencies": { "typescript": "^5 || ^6" }, "optionalPeers": ["typescript"] }, "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -1500,6 +1506,8 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
+    "react-i18next": ["react-i18next@17.0.8", "", { "dependencies": { "@babel/runtime": "^7.29.2", "html-parse-stringify": "^3.0.1", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "i18next": ">= 26.2.0", "react": ">= 16.8.0", "react-dom": "*", "react-native": "*", "typescript": "^5 || ^6" }, "optionalPeers": ["react-dom", "react-native", "typescript"] }, "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw=="],
+
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
@@ -1707,6 +1715,8 @@
     "vite": ["vite@8.0.11", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.14", "rolldown": "1.0.0-rc.18", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Jz1mxtUBR5xTT65VOdJZUUeoyLtqljmFkiUXhPTLZka3RDc9vpi/xXkyrnsdRcm2lIi3l3GPMnAidTsEGIj3Ow=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "void-elements": ["void-elements@3.1.0", "", {}, "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w=="],
 
     "web": ["web@workspace:apps/web"],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "lint": "turbo run lint"
   },
   "dependencies": {
-    "minimatch": "^10.2.5"
+    "i18next": "^26.2.0",
+    "minimatch": "^10.2.5",
+    "react-i18next": "^17.0.8"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",


### PR DESCRIPTION
## Summary

This PR adds the initial internationalization (i18n) infrastructure and translates core UI strings.

## Changes

### Dependencies
- Added `i18next`
- Added `react-i18next`

### Setup
- Added i18n configuration
- Added English translation dictionary
- Added French translation dictionary
- Initialized translations at application startup

### UI Translation
- Search bar
- Advanced search dialog
- Search results
- Schedule generation controls
- Footer
- Clear results button
- Loading states

## Commits

1. Add i18n dependencies
2. Set up i18n translations
3. Translate initial UI strings

## Notes

This is the first step toward full bilingual support. Additional components and pages will be translated in future PRs.